### PR TITLE
fixed: conflict avoided when an activity ends on beginning of other

### DIFF
--- a/src/entities/Activity.ts
+++ b/src/entities/Activity.ts
@@ -75,16 +75,19 @@ export default class Activity extends BaseEntity implements IActivity {
   }
 
   static async hasConflictant(desiredActivity: IActivity, enrollment: IEnrollment) {
+    const oneSecondBeforeEnd = new Date(desiredActivity.endDate.getTime()-1);
+    const oneSecondAfterStart = new Date(desiredActivity.startDate.getTime()+1);
+
     const conflictantsActivities = await this.find(
       {
         where: [
           { 
             id: Not(desiredActivity.id),
-            startDate: Between(desiredActivity.startDate, desiredActivity.endDate)
+            startDate: Between(desiredActivity.startDate, oneSecondBeforeEnd)
           },
           { 
             id: Not(desiredActivity.id),
-            endDate: Between(desiredActivity.startDate, desiredActivity.endDate)
+            endDate: Between(oneSecondAfterStart, desiredActivity.endDate)
           }
         ],
         relations: [


### PR DESCRIPTION
I fixed a bug.
When an activity was starting at the time another was ending, or vice versa, it was raising a conflict error when it shouldn't.